### PR TITLE
Fix creating and editing propositions as global admin

### DIFF
--- a/src/ekklesia_portal/concepts/proposition/proposition_cells.py
+++ b/src/ekklesia_portal/concepts/proposition/proposition_cells.py
@@ -27,8 +27,21 @@ class PropositionCell(LayoutCell):
     _model: Proposition
 
     model_properties = [
-        'abstract', 'ballot', 'content', 'created_at', 'submitted_at', 'qualified_at', 'derivations',
-        'external_discussion_url', 'id', 'modifies', 'motivation', 'replacements', 'replaces', 'tags', 'title',
+        'abstract',
+        'ballot',
+        'content',
+        'created_at',
+        'submitted_at',
+        'qualified_at',
+        'derivations',
+        'external_discussion_url',
+        'id',
+        'modifies',
+        'motivation',
+        'replacements',
+        'replaces',
+        'tags',
+        'title',
     ]
 
     actions = Cell.fragment('proposition_actions')

--- a/src/ekklesia_portal/concepts/proposition/proposition_views.py
+++ b/src/ekklesia_portal/concepts/proposition/proposition_views.py
@@ -181,7 +181,10 @@ def create(self, request, appstruct):
         # create a new ballot as "container" for the proposition
         area = request.q(SubjectArea).get(appstruct['area_id']) if appstruct['area_id'] else None
 
-        if area is None or area.department not in request.current_user.departments:
+        if area is None:
+            return HTTPBadRequest()
+
+        if area.department not in request.current_user.departments and not request.identity.has_global_admin_permissions:
             return HTTPBadRequest()
 
         ballot = Ballot(area=area)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -124,6 +124,7 @@ class BallotFactory(SQLAFactory):
     election = FuzzyChoice([0, 4, 8])
     voting_type = FuzzyChoice(list(VotingType))
     proposition_type = SubFactory(PropositionTypeFactory)
+    area = SubFactory(SubjectAreaFactory)
     result = {}
 
 

--- a/tests/helpers/webtest_helpers.py
+++ b/tests/helpers/webtest_helpers.py
@@ -17,19 +17,26 @@ def python_to_deform_value(py_value):
 def assert_deform(response, expected_form_data={}):
     assert 'deform' in response.forms
     form = response.forms['deform']
+    missing_fields = []
 
     for field, value in expected_form_data.items():
         if field == 'id':
             continue
 
         try:
-            form_field = form[field]
+            form[field]
         except AssertionError:
-            raise AssertionError(f"expected form field '{field}' is missing")
+            missing_fields.append(field)
+            continue
+
         form_value = form[field].value
 
         deform_value = python_to_deform_value(value)
         assert form_value == deform_value, f'form field {field}: form value {form_value} != expected {deform_value}'
+
+    if missing_fields:
+        fields_str = ", ".join(missing_fields)
+        raise AssertionError(f"missing expected form fields: '{fields_str}'")
 
     return form
 


### PR DESCRIPTION
Global admins should be able to create and edit propositions if they are not
member of the department.

Also improves assert_deform to show all missing expected form fields at once.

Fixes #26