### PR TITLE
login: Do not show password in cleartext

### DIFF
--- a/src/ekklesia_portal/concepts/ekklesia_portal/templates/login.j2.jade
+++ b/src/ekklesia_portal/concepts/ekklesia_portal/templates/login.j2.jade
@@ -27,7 +27,7 @@
 
       p
         label(for="password") Password
-        input(name="password")
+        input(name="password" type="password")
 
       input(type="submit")
 


### PR DESCRIPTION
When logging in, the password is visible in clear text. This fixes it. It also makes it easier for the browser to store the password.