### PR TITLE
Implement sort by date button in propositions view

### DIFF
--- a/src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade
@@ -19,6 +19,10 @@
       a.nav-link(class=("active" if sort=="supporter_count" else ""), href=change_self_link(sort="supporter_count"))
         = _("btn_sort_by_supporter_count")
 
+    li.nav-item
+      a.nav-link(class=("active" if sort=="date" else ""), href=change_self_link(sort="date"))
+        = _("btn_sort_by_date")
+
 
   ul.filter-nav
 

--- a/src/ekklesia_portal/identity_policy.py
+++ b/src/ekklesia_portal/identity_policy.py
@@ -49,4 +49,5 @@ class EkklesiaPortalIdentityPolicy(morepath.IdentityPolicy):
         )
 
     def forget(self, response, request):
-        del request.browser_session['user_id']
+        if 'user_id' in request.browser_session:
+            del request.browser_session['user_id']

--- a/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
@@ -714,13 +714,17 @@ msgstr[1] "Unterstützer"
 msgid "created_on"
 msgstr "Erstellt am %(date)s"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:6
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:16
 msgid "btn_sort_by_identifier_or_title"
 msgstr "Nach Kennung/Titel sortieren"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:8
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:20
 msgid "btn_sort_by_supporter_count"
 msgstr "Nach Unterstützeranzahl sortieren"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:24
+msgid "btn_sort_by_date"
+msgstr "Nach Datum sortieren"
 
 #: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:13
 msgid "department_propositions"

--- a/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
@@ -713,13 +713,17 @@ msgstr[1] "Supporters"
 msgid "created_on"
 msgstr "Added on %(date)s"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:6
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:16
 msgid "btn_sort_by_identifier_or_title"
 msgstr "Sort by Identifier/Title"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:8
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:20
 msgid "btn_sort_by_supporter_count"
 msgstr "Sort by Supporter Count"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:24
+msgid "btn_sort_by_date"
+msgstr "Sort by Date"
 
 #: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:13
 msgid "department_propositions"


### PR DESCRIPTION
- To sort by date, the submit date is used if it is set, otherwise the creation date is used
  This should be quite intuitive. When a draft is created, it is shown at the top with this sorting setting. When the proposition is submitted, it is again put to the top because the content has changed. When the proposition changes again (e.g. qualified) the content doesn't change so it does not need to be put to the top again.


Also fix error when logging out twice and remove the duplicated `section` field.
Closes #67

