### PR TITLE
Fully implement draft workflow

### DIFF
--- a/alembic/versions/0b17ab7f0a04_add_proposition_submitter_invitation_key.py
+++ b/alembic/versions/0b17ab7f0a04_add_proposition_submitter_invitation_key.py
@@ -1,0 +1,24 @@
+"""Add Proposition.submitter_invitation_key
+
+Revision ID: 0b17ab7f0a04
+Revises: fce689b4e91f
+Create Date: 2020-08-15 21:39:25.068276
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0b17ab7f0a04'
+down_revision = 'fce689b4e91f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('propositions', sa.Column('submitter_invitation_key', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('propositions', 'submitter_invitation_key')

--- a/alembic/versions/6d782ad96592_empty_default_for_proposition_external_fields.py
+++ b/alembic/versions/6d782ad96592_empty_default_for_proposition_external_fields.py
@@ -1,0 +1,33 @@
+"""Empty default for proposition.external_fields
+
+Revision ID: 6d782ad96592
+Revises: 0b17ab7f0a04
+Create Date: 2020-08-15 23:33:04.586549
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '6d782ad96592'
+down_revision = '0b17ab7f0a04'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("UPDATE propositions SET external_fields = '{}' WHERE external_fields IS NULL")
+    op.alter_column('propositions', 'external_fields',
+               existing_type=postgresql.JSONB(astext_type=sa.Text()),
+               server_default='{}',
+               existing_comment='Fields that are imported from or exported to other systems but are not interpreted by the portal.',
+               nullable=False)
+
+
+def downgrade():
+    op.alter_column('propositions', 'external_fields',
+               existing_type=postgresql.JSONB(astext_type=sa.Text()),
+               server_default=None,
+               existing_comment='Fields that are imported from or exported to other systems but are not interpreted by the portal.',
+               nullable=True)

--- a/alembic/versions/fce689b4e91f_add_proposition_author.py
+++ b/alembic/versions/fce689b4e91f_add_proposition_author.py
@@ -1,0 +1,26 @@
+"""Add Proposition.author
+
+Revision ID: fce689b4e91f
+Revises: 2ef4af95efe9
+Create Date: 2020-08-15 21:02:09.176120
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'fce689b4e91f'
+down_revision = '2ef4af95efe9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('propositions', sa.Column('author_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(op.f('fk_propositions_author_id_users'), 'propositions', 'users', ['author_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint(op.f('fk_propositions_author_id_users'), 'propositions', type_='foreignkey')
+    op.drop_column('propositions', 'author_id')

--- a/src/ekklesia_portal/concepts/proposition/proposition_contracts.py
+++ b/src/ekklesia_portal/concepts/proposition/proposition_contracts.py
@@ -43,6 +43,8 @@ class PropositionNewSchema(PropositionSchema):
 
 class PropositionEditSchema(PropositionSchema):
     voting_identifier = string_property(title=_('voting_identifier'), validator=Length(max=10), missing=None)
+    submitter_invitation_key = string_property(title=_('submitter_invitation_key'), missing=None)
+    external_discussion_url = string_property(title=_('external_discussion_url'), validator=colander.url, missing='')
     status = enum_property(PropositionStatus, title=_('status'))
     visibility = enum_property(PropositionVisibility, title=_('visibility'))
     external_fields = json_property(title=_('external_fields'), missing={})
@@ -67,10 +69,11 @@ class PropositionNewDraftSchema(Schema):
 class PropositionNewForm(Form):
 
     def __init__(self, request, action):
-        super().__init__(PropositionNewSchema(), request, action, buttons=[Button(title=_("submit"))])
+        super().__init__(PropositionNewSchema(), request, action, buttons=[Button(title=_("button_create_draft"))])
 
     def prepare_for_render(self, items_for_selects):
         self.set_widgets({
+            'editing_remarks': TextAreaWidget(rows=4),
             'area_id': Select2Widget(values=items_for_selects['area']),
             'proposition_type_id': Select2Widget(values=items_for_selects['proposition_type']),
             **common_widgets(items_for_selects)
@@ -94,7 +97,7 @@ class PropositionEditForm(Form):
 class PropositionNewDraftForm(Form):
 
     def __init__(self, request, action):
-        super().__init__(PropositionNewDraftSchema(), request, action, buttons=[Button(title=_("submit"))])
+        super().__init__(PropositionNewDraftSchema(), request, action, buttons=[Button(title=_("button_create_draft"))])
 
     def prepare_for_render(self, items_for_selects):
         common = common_widgets(items_for_selects)
@@ -108,3 +111,12 @@ class PropositionNewDraftForm(Form):
             'motivation': common['motivation'],
             'tags': common['tags']
         })
+
+
+class PropositionSubmitDraftForm(Form):
+
+    def __init__(self, request, action):
+        super().__init__(PropositionSchema(), request, action, buttons=[Button(title=_("button_submit_draft"))])
+
+    def prepare_for_render(self, items_for_selects):
+        self.set_widgets(common_widgets(items_for_selects))

--- a/src/ekklesia_portal/concepts/proposition/proposition_helper.py
+++ b/src/ekklesia_portal/concepts/proposition/proposition_helper.py
@@ -1,10 +1,18 @@
 from operator import attrgetter
 
-import case_conversion
+from slugify import slugify
 from ekklesia_common.translation import _
 
 from ekklesia_portal.datamodel import Tag
 from ekklesia_portal.enums import PropositionStatus, PropositionVisibility
+
+
+slug_replacements = [
+    ['Ü', 'Ue'], ['ü', 'ue'],
+    ['Ö', 'Oe'], ['ö', 'oe'],
+    ['Ä', 'Ae'], ['ä', 'ae'],
+    ['ß', 'ss']
+]
 
 
 def items_for_proposition_select_widgets(departments, tags, proposition_types=None, selected_tags=None):
@@ -44,4 +52,4 @@ def get_or_create_tags(db_session, tag_names):
 
 
 def proposition_slug(proposition):
-    return case_conversion.dashcase(proposition.title)
+    return slugify(proposition.title, replacements=slug_replacements)

--- a/src/ekklesia_portal/concepts/proposition/proposition_permissions.py
+++ b/src/ekklesia_portal/concepts/proposition/proposition_permissions.py
@@ -1,0 +1,9 @@
+from ekklesia_common.permission import WritePermission
+
+
+class NewDraftPermission(WritePermission):
+    pass
+
+
+class SubmitDraftPermission(WritePermission):
+    pass

--- a/src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade
@@ -1,0 +1,40 @@
+h2= _('title_draft')
+
+p= _('notice_proposition_is_a_draft')
+
+if current_user_is_submitter and current_user_is_author
+  p= _('you_are_author_and_submitter')
+elif current_user_is_author
+  p= _('you_are_author_but_not_submitter')
+elif current_user_is_submitter
+  p= _('you_are_submitter')
+
+
+if ready_to_submit
+  p= _('draft_ready_to_submit')
+else
+  p= _('draft_needs_more_submitters', missing=missing_submitters_count)
+
+  if current_user_is_author or current_user_is_submitter
+    p= _('share_this_become_submitter_link')
+    p
+      a(href=become_submitter_url)= become_submitter_url
+
+    p {{ _('current_submitters') }}
+    ul
+      for name in submitter_names
+        li= name
+
+  if valid_submitter_invitation_key and not current_user_is_submitter
+    p = _('invited_to_become_submitter')
+
+    if current_user
+      form.become_submitter_form(action=become_submitter_action, method="POST")
+        input(type="hidden",name="submitter_invitation_key", value=submitter_invitation_key)
+        button.btn.btn-primary.btn-sm(type="submit", name="become_submitter")
+            i.far.fa-thumbs-up &nbsp;
+            = _('button_become_submitter')
+    else
+      p
+        a(href=login_url)= _('notice_login')
+

--- a/src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_qualified.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_qualified.j2.jade
@@ -1,0 +1,5 @@
+h2= _('title_qualified_proposition')
+
+p= _('info_qualified_proposition')
+
+

--- a/src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_scheduled.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_scheduled.j2.jade
@@ -1,0 +1,5 @@
+h2= _('title_scheduled_proposition')
+
+p= _('info_scheduled_proposition', ballot=ballot_title, voting_phase=voting_phase.title)
+
+

--- a/src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade
@@ -1,0 +1,12 @@
+h2= _('title_submitted_proposition')
+
+p= _('info_submitted_proposition')
+
+if current_user_is_submitter
+  p= _('current_user_is_submitter')
+
+  if current_user_is_supporter
+    p= _('current_user_is_submitter_and_supporter')
+
+elif current_user_is_supporter
+  p= _('current_user_is_supporter_not_submitter')

--- a/src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade
@@ -11,6 +11,9 @@
     dd= department_name
     dt= _('subject_area')
     dd= subject_area_name
+    dt= _('submitter_invitation_link')
+    dd
+      a(href=become_submitter_url)= become_submitter_url
     dt= _('ballot')
     dd
       a(href=ballot_url)

--- a/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade
@@ -1,2 +1,7 @@
+if show_full_history
+  if author
+    .proposition_history_item
+      = _("created_by", author=author.name)
+
 .proposition_history_item
   = _("created_on", date=created_at|dateformat)

--- a/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade
@@ -1,4 +1,8 @@
 if show_full_history
+  if author
+    .proposition_history_item
+      = _("created_by", author=author.name)
+
   .proposition_history_item
     = _("created_on", date=created_at|dateformat)
 

--- a/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade
@@ -1,4 +1,8 @@
 if show_full_history
+  if author
+    .proposition_history_item
+      = _("created_by", author=author.name)
+
   .proposition_history_item
     = _("created_on", date=created_at|dateformat)
 

--- a/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade
@@ -1,4 +1,8 @@
 if show_full_history
+  if author
+    .proposition_history_item
+      = _("created_by", author=author.name)
+
   .proposition_history_item
     = _("created_on", date=created_at|dateformat)
 

--- a/src/ekklesia_portal/concepts/proposition/templates/new_proposition.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/new_proposition.j2.jade
@@ -1,10 +1,12 @@
 - extends "ekklesia_portal/layout.j2.jade"
 
 - block title
-  title= _("title_new_proposition")
+  title= _("title_new_draft")
 
 - block content
-  h2= _("title_new_proposition")
+  h2= _("title_new_draft")
+
+  = new_draft_explanation|markdown
 
   = form_html
 

--- a/src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade
@@ -8,6 +8,10 @@
 
 - block content
 
+  if options.show_details
+    = render_cell(_model, 'detail_top', **options)
+
+
   .proposition(id="proposition_{{ id }}", class=("" if options.margin else "proposition_no_margin"))
     if options.show_tabs
       .proposition_toolbar
@@ -18,8 +22,9 @@
           li.nav-item
             a.nav-link(href=associated_url, class=associated_link_class)= _("tab_associated")
 
-    .card-body(class=("" if not is_supported_by_current_user else "card-body-supported"))
+    .card-body(class=("" if not current_user_is_supporter else "card-body-supported"))
       = render_cell(_model, 'card', **options)
+
 
   if options.active_tab == 'discussion'
     .row.arguments

--- a/src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade
@@ -1,13 +1,18 @@
 .proposition_actions
   if show_support_actions
     form.support_form(action=support_action, method="POST")
-      button.btn.btn-primary.btn-sm(hidden=is_supported_by_current_user, type="submit", name="support")
+      button.btn.btn-primary.btn-sm(hidden=current_user_is_supporter, type="submit", name="support")
           i.far.fa-thumbs-up &nbsp;
           = _('button_support')
 
-      button.btn.btn-secondary.btn-sm(hidden=(not is_supported_by_current_user), type="submit", name="retract")
+      button.btn.btn-secondary.btn-sm(hidden=(not current_user_is_supporter), type="submit", name="retract")
           i.far.fa-remove &nbsp;
           = _('button_retract_support')
+
+  if show_submit_draft_action
+      a.btn.btn-primary.btn-sm(href=submit_draft_url)
+          i.far.fa-paper-plane &nbsp;
+          = _('button_submit_draft')
 
   a.btn.btn-secondary.btn-sm(href='javascript:;', data-toggle='popover', data-popover-content='#a1')
     i.fas.fa-link &nbsp;

--- a/src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade
+++ b/src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade
@@ -1,0 +1,31 @@
+- extends "ekklesia_portal/layout.j2.jade"
+
+- block title
+  title= _("title_submit_draft")
+
+- block content
+
+  if draft_not_fully_matched
+    .alert.alert-danger
+      = _("alert_draft_not_fully_matched")
+
+  h2= _("title_submit_draft")
+
+  .notice
+    .notice-header
+        strong= _('title_notice')
+    .notice-body
+      = explanation|markdown
+
+  dl
+    dt= _('department')
+    dd= department_name
+    dt= _('subject_area')
+    dd= subject_area_name
+    dt= _('proposition_type')
+    dd= proposition_type_name
+
+  = form_html
+
+
+//- vim: set filetype=jade sw=2 ts=2 sts=2 expandtab:

--- a/src/ekklesia_portal/exporter/discourse.py
+++ b/src/ekklesia_portal/exporter/discourse.py
@@ -1,0 +1,38 @@
+import requests
+from eliot import start_task
+from ekklesia_portal.enums import PropositionVisibility
+
+from ekklesia_portal.lib.discourse import DiscourseConfig, DiscourseTopic, create_discourse_topic
+
+
+def push_draft_to_discourse(
+    exporter_config, external_content_template, portal_content_template, proposition, proposition_url
+):
+
+    editing_remarks = proposition.external_fields['external_draft']['editing_remarks']
+
+    content = external_content_template.format(
+        draft_link=proposition_url,
+        editing_remarks=editing_remarks,
+        abstract=proposition.abstract,
+        content=proposition.content,
+        motivation=proposition.motivation
+    )
+
+    importer_name = exporter_config.pop("importer")
+
+    topic = DiscourseTopic(content, proposition.title, [t.name for t in proposition.tags])
+    discourse_config = DiscourseConfig(**exporter_config)
+    resp_json = create_discourse_topic(discourse_config, topic).json()
+    topic_id = resp_json["topic_id"]
+    topic_slug = resp_json["topic_slug"]
+    discourse_topic_url = f'{discourse_config.base_url}/t/{topic_slug}/{topic_id}'
+    proposition.external_discussion_url = discourse_topic_url
+    external_draft = proposition.external_fields["external_draft"]
+    external_draft['import_info'] = {'topic_id': topic_id}
+    external_draft['importer'] = importer_name
+    proposition.external_fields['external_draft'] = external_draft
+    proposition.content = portal_content_template.format(topic_url=discourse_topic_url)
+    proposition.motivation = ''
+    proposition.abstract = ''
+    proposition.visibility = PropositionVisibility.PUBLIC

--- a/src/ekklesia_portal/importer/__init__.py
+++ b/src/ekklesia_portal/importer/__init__.py
@@ -1,6 +1,9 @@
-from .discourse import import_discourse_post_as_proposition
+from .discourse import import_discourse_post_as_proposition, import_discourse_topic_as_proposition
 
 # import handlers are functions with the following signature:
-# def import_handler(base_url: str, from_data: str)
+# def import_handler(config: dict, from_data: str)
 # this assumes that we want to import data from some url with some ID, but from_data can be anything
-PROPOSITION_IMPORT_HANDLERS = {"discourse_post": import_discourse_post_as_proposition}
+PROPOSITION_IMPORT_HANDLERS = {
+    "discourse_post": import_discourse_post_as_proposition,
+    "discourse_topic": import_discourse_topic_as_proposition,
+}

--- a/src/ekklesia_portal/importer/discourse.py
+++ b/src/ekklesia_portal/importer/discourse.py
@@ -1,30 +1,56 @@
 import re
 
+from eliot import start_action
 import requests
 
 
+regex_flags = re.MULTILINE | re.UNICODE
+subsection_pattern = '((?:[^#]|#{3,})*)'
+abstract_header = '^## (?:(?:Zusammenfassung)|(?:Abstract))\n+'
+content_header = '^## (?:(?:Antragstext)|(?:Proposition))\n+'
+motivation_header = '^## (?:(?:Begründung)|(?:Motivation))\n+'
+
+content_re = re.compile(content_header + subsection_pattern, regex_flags)
+abstract_re = re.compile(abstract_header + subsection_pattern, regex_flags)
+motivation_re = re.compile(motivation_header + subsection_pattern, regex_flags)
+
 def parse_raw_content(raw: str):
-    subsection_pattern = '((?:[^#]|#{3,})+)'
-    abstract_header = '^## (?:(?:Zusammenfassung)|(?:Abstract))\n+'
-    content_header = '^## (?:(?:Proposition)|(?:Antrag))\n+'
-    motivation_header = '^## (?:(?:Motivation)|(?:Begründung))\n+'
 
-    abstract_match = re.search(abstract_header + subsection_pattern, raw, re.MULTILINE)
-    content_match = re.search(content_header + subsection_pattern, raw, re.MULTILINE)
-    motivation_match = re.search(motivation_header + subsection_pattern, raw, re.MULTILINE)
+    content_match = content_re.search(raw)
+    abstract_match = abstract_re.search(raw)
+    motivation_match = motivation_re.search(raw)
 
-    return {
-        'abstract': abstract_match.group(1).strip() if abstract_match else None,
-        'content': content_match.group(1).strip() if content_match else None,
-        'motivation': motivation_match.group(1).strip() if motivation_match else None
-    }
+    with start_action(action_type="discourse_parse_raw_content", raw=raw, content_match=content_match,
+                      abstract_match=abstract_match, motivation_match=motivation_match) as action:
+
+        if content_match:
+            abstract = abstract_match.group(1).strip() if abstract_match else None
+            content = content_match.group(1).strip()
+            motivation = motivation_match.group(1).strip() if motivation_match else None
+            all_matched = bool(content_match and abstract_match and motivation_match)
+            action.add_success_fields(
+                all_matched=all_matched, abstract=abstract, content=content, motivation=motivation
+            )
+        else:
+            content = raw
+            abstract = None
+            motivation = None
+            all_matched = False
+
+    return {'abstract': abstract, 'content': content, 'motivation': motivation, 'all_matched': all_matched}
 
 
-def import_discourse_post_as_proposition(base_url: str, from_data):
+def import_discourse_post_as_proposition(config: dict, from_data):
+    base_url = config["base_url"]
     post_id = int(from_data)
     post_url = f"{base_url}/posts/{post_id}"
 
-    res = requests.get(post_url, headers=dict(Accept="application/json"))
+    headers = {'accept': 'application/json'}
+    if "api_key" in config:
+        headers['api-key'] = config["api_key"]
+        headers['api-username'] = config["api_username"]
+
+    res = requests.get(post_url, headers=headers)
     post_data = res.json()
 
     raw = post_data.get("raw")
@@ -38,11 +64,47 @@ def import_discourse_post_as_proposition(base_url: str, from_data):
         raise ValueError("malformed discourse post JSON, key 'topic_id' not found!")
 
     topic_url = f"{base_url}/t/{topic_id}"
-    res = requests.get(topic_url, headers=dict(Accept="application/json"))
+    res = requests.get(topic_url, headers=headers)
     topic_data = res.json()
 
     title = topic_data.get("title")
     if title is None:
         raise ValueError("malformed discourse topic JSON, key 'title' not found!")
+
+    return {'title': title, 'external_discussion_url': topic_url, **parsed_content}
+
+
+def import_discourse_topic_as_proposition(config: dict, import_info):
+    base_url = config["base_url"]
+    topic_id = int(import_info["topic_id"])
+
+    topic_url = f"{base_url}/t/{topic_id}"
+
+    headers = {'accept': 'application/json'}
+    if "api_key" in config:
+        headers['api-key'] = config["api_key"]
+        headers['api-username'] = config["api_username"]
+
+    res = requests.get(topic_url, headers=headers)
+    topic_data = res.json()
+
+    title = topic_data.get("title")
+    if title is None:
+        raise ValueError("malformed discourse topic JSON, key 'title' not found!")
+
+    post_id = topic_data.get("post_stream", {}).get("posts")[0]["id"]
+    if post_id is None:
+        raise ValueError("malformed discourse post JSON, id of first post not found!")
+
+    post_url = f"{base_url}/posts/{post_id}"
+
+    res = requests.get(post_url, headers=headers)
+    post_data = res.json()
+
+    raw = post_data.get("raw")
+    if raw is None:
+        raise ValueError("malformed discourse post JSON, key 'raw' not found!")
+
+    parsed_content = parse_raw_content(raw)
 
     return {'title': title, 'external_discussion_url': topic_url, **parsed_content}

--- a/src/ekklesia_portal/lib/discourse.py
+++ b/src/ekklesia_portal/lib/discourse.py
@@ -1,7 +1,9 @@
+from eliot import start_action
 from dataclasses import dataclass
 from typing import List
 
 import requests
+from requests import HTTPError
 
 
 @dataclass
@@ -19,11 +21,23 @@ class DiscourseConfig:
     category: int
 
 
+class DiscourseError(Exception):
+    pass
+
+
 def create_discourse_topic(config: DiscourseConfig, topic: DiscourseTopic):
 
     headers = {'accept': 'application/json', 'api-key': config.api_key, 'api-username': config.api_username}
 
     req = {'raw': topic.content, 'category': config.category, 'title': topic.title, 'tags': topic.tags}
 
-    resp = requests.post(f"{config.base_url}/posts.json", json=req, headers=headers)
+    with start_action(action_type="discourse_post") as action:
+        resp = requests.post(f"{config.base_url}/posts.json", json=req, headers=headers)
+        action.add_success_fields(response=resp.json())
+
+    try:
+        resp.raise_for_status()
+    except HTTPError as e:
+        raise DiscourseError(e)
+
     return resp

--- a/src/ekklesia_portal/sass/portal.sass
+++ b/src/ekklesia_portal/sass/portal.sass
@@ -168,6 +168,24 @@ footer.footer
   .nav-link.active
     color: $link_color
 
+.notice
+  @extend .card
+  margin-bottom: 1rem
+  border:
+
+  .notice-header
+    @extend .card-header
+
+  .notice-body
+    padding: 1rem
+    @extend .card-body
+
+    .notice-title
+      @extend .card-title
+
+    p:last-child
+      margin-bottom: 0
+
 .sort-nav
   padding-left: 0.5rem
 

--- a/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-05 17:57+0000\n"
+"POT-Creation-Date: 2020-12-08 17:32+0000\n"
 "PO-Revision-Date: 2015-09-06 22:42+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -16,19 +16,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.8.0\n"
+"Generated-By: Babel 2.9.0\n"
 
 #: src/ekklesia_portal/concepts/argument/argument_contracts.py:12
 #: src/ekklesia_portal/concepts/page/page_contracts.py:11
 #: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:24
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:47
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:54
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_contracts.py:12
 msgid "title"
 msgstr "Titel"
 
 #: src/ekklesia_portal/concepts/argument/argument_contracts.py:13
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:25
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:51
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:28
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:58
 msgid "abstract"
 msgstr "Zusammenfassung"
 
@@ -45,9 +45,7 @@ msgstr "Ausführlich"
 #: src/ekklesia_portal/concepts/ekklesia_portal/contracts/token.py:14
 #: src/ekklesia_portal/concepts/page/page_contracts.py:19
 #: src/ekklesia_portal/concepts/policy/policy_contracts.py:30
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:65
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:78
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:92
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:86
 #: src/ekklesia_portal/concepts/proposition_note/proposition_note_contracts.py:20
 #: src/ekklesia_portal/concepts/proposition_type/proposition_type_contracts.py:18
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_contracts.py:24
@@ -100,8 +98,9 @@ msgstr "Ergebnis"
 #: src/ekklesia_portal/concepts/ballot/ballot_contracts.py:12
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:23
 #: src/ekklesia_portal/concepts/document/document_contracts.py:11
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:35
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:34
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:7
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:15
 msgid "subject_area"
 msgstr "Themenbereich"
 
@@ -114,7 +113,8 @@ msgstr "Abstimmungszeitraum"
 #: src/ekklesia_portal/concepts/ballot/ballot_contracts.py:14
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:25
 #: src/ekklesia_portal/concepts/document/templates/document.j2.jade:15
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:36
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:35
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:17
 #: src/ekklesia_portal/concepts/proposition_type/templates/proposition_type.j2.jade:3
 msgid "proposition_type"
 msgstr "Antragsart"
@@ -131,8 +131,8 @@ msgstr "nicht festgelegt"
 
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:3
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:7
-#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:9
-#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:10
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:12
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:13
 #: src/ekklesia_portal/concepts/proposition/templates/status/proposition_status_scheduled.j2.jade:6
 msgid "ballot"
 msgstr "Abstimmung"
@@ -143,7 +143,7 @@ msgstr "Abstimmung"
 #: src/ekklesia_portal/concepts/document/templates/document.j2.jade:10
 #: src/ekklesia_portal/concepts/page/templates/page.j2.jade:7
 #: src/ekklesia_portal/concepts/policy/templates/policy.j2.jade:7
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 #: src/ekklesia_portal/concepts/proposition_note/templates/proposition_note.j2.jade:7
 #: src/ekklesia_portal/concepts/proposition_type/templates/proposition_type.j2.jade:7
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:9
@@ -162,6 +162,7 @@ msgstr "Anzahl der Anträge"
 #: src/ekklesia_portal/concepts/department/templates/department.j2.jade:3
 #: src/ekklesia_portal/concepts/department/templates/department.j2.jade:5
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:5
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:13
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:19
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_contracts.py:15
 msgid "department"
@@ -325,6 +326,8 @@ msgid "button_login"
 msgstr "Anmelden"
 
 #: src/ekklesia_portal/concepts/ekklesia_portal/templates/index.j2.jade:9
+#: src/ekklesia_portal/concepts/proposition/templates/new_proposition.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/new_proposition.j2.jade:3
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_new_draft.j2.jade:2
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_new_draft.j2.jade:3
 msgid "title_new_draft"
@@ -368,7 +371,7 @@ msgid "menu_propositions"
 msgstr "Anträge"
 
 #: src/ekklesia_portal/concepts/ekklesia_portal/templates/layout.j2.jade:34
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:49
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:51
 msgid "search_for"
 msgstr "Suchen nach"
 
@@ -517,8 +520,8 @@ msgstr "Abstimmungssystem"
 
 #: src/ekklesia_portal/concepts/policy/policy_helper.py:7
 #: src/ekklesia_portal/concepts/policy/policy_helper.py:8
-#: src/ekklesia_portal/concepts/proposition/proposition_helper.py:17
-#: src/ekklesia_portal/concepts/proposition/proposition_helper.py:18
+#: src/ekklesia_portal/concepts/proposition/proposition_helper.py:25
+#: src/ekklesia_portal/concepts/proposition/proposition_helper.py:26
 #: src/ekklesia_portal/concepts/proposition_note/proposition_note_helper.py:9
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_helper.py:7
 msgid "_"
@@ -545,54 +548,70 @@ msgstr "Regelwerk"
 msgid "days"
 msgstr "Tage"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:26
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:48
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:25
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:55
 msgid "content"
 msgstr "Text"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:27
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:52
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:26
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:56
 msgid "motivation"
 msgstr "Begründung"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:28
-msgid "external_discussion_url"
-msgstr "Link zur Diskussion"
-
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:29
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:59
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:27
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:57
 msgid "tags"
 msgstr "Tags"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:40
-msgid "voting_identifier"
-msgstr "Kennung für Abstimmung"
-
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:41
-msgid "status"
-msgstr "Status"
-
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:42
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:33
-msgid "visibility"
-msgstr "Sichtbarkeit"
-
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:43
-msgid "external_fields"
-msgstr "Daten für externe Systeme"
-
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:54
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:37
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:60
 msgid "editing_remarks"
 msgstr "Anmerkungen zur Antragsentwicklung"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:55
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:38
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:61
 msgid "editing_remarks_description"
 msgstr ""
 "Hier kannst du z.B. angeben, welche Gruppe am Antrag arbeitet und wie "
 "Andere Verbesserungen einbringen können. Wird in der Antragsentwicklung "
 "vor dem Antrag eingefügt."
 
-#: src/ekklesia_portal/concepts/proposition/proposition_views.py:245
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:45
+msgid "voting_identifier"
+msgstr "Kennung für Abstimmung"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:46
+msgid "submitter_invitation_key"
+msgstr "Einladungs-Schlüssel für Antragsteller"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:47
+msgid "external_discussion_url"
+msgstr "Link zur Diskussion"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:48
+msgid "status"
+msgstr "Status"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:49
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:35
+msgid "visibility"
+msgstr "Sichtbarkeit"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:50
+msgid "external_fields"
+msgstr "Daten für externe Systeme"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:72
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:100
+msgid "button_create_draft"
+msgstr "Antragsentwurf anlegen"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:119
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
+msgid "button_submit_draft"
+msgstr "Antrag einreichen"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_views.py:319
 msgid "change"
 msgstr "Änderung"
 
@@ -601,22 +620,21 @@ msgstr "Änderung"
 msgid "title_edit_proposition"
 msgstr "Antrag bearbeiten"
 
-#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:14
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:9
+msgid "submitter_invitation_link"
+msgstr "Einladungslink für Antragsteller"
+
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:17
 msgid "push_draft"
 msgstr "Antragsentwurf übertragen"
 
-#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:15
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:18
 msgid "exporter_target"
 msgstr "Ziel für Export"
 
-#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:19
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:22
 msgid "push_draft_button"
 msgstr "Antragsentwurf übertragen"
-
-#: src/ekklesia_portal/concepts/proposition/templates/new_proposition.j2.jade:2
-#: src/ekklesia_portal/concepts/proposition/templates/new_proposition.j2.jade:3
-msgid "title_new_proposition"
-msgstr "Neuer Antrag"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:6
 msgid "tab_discussion"
@@ -648,7 +666,7 @@ msgstr "Änderungsantrag stellen"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:43
 msgid "title_proposition_replaces"
-msgstr "Ist Gegenantrag zu"
+msgstr "Ist Konkurrenzantrag zu"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:48
 msgid "title_proposition_replacements"
@@ -670,27 +688,27 @@ msgstr "Unterstützung zurückziehen"
 msgid "button_share"
 msgstr "Teilen"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 msgid "button_external_discussion_url"
 msgstr "Externe Diskussion"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 msgid "button_goto_arguments"
 msgstr "Zu den Argumenten"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 msgid "button_goto_associated"
 msgstr "Zu den Konkurrenzanträgen"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 msgid "button_report"
 msgstr "Melden"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 msgid "note_button"
 msgstr "Notizen"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_card.j2.jade:9
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_card.j2.jade:10
 msgid "title_motivation"
 msgstr "Begründung"
 
@@ -706,90 +724,197 @@ msgid_plural "supporters"
 msgstr[0] "Unterstützer"
 msgstr[1] "Unterstützer"
 
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade:1
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:2
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:2
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade:4
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:4
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:4
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:4
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_small.j2.jade:12
 msgid "created_on"
 msgstr "Erstellt am %(date)s"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:16
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:5
+msgid "title_submit_draft"
+msgstr "Antrag einreichen"
+
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:3
+msgid "alert_draft_not_fully_matched"
+msgstr ""
+"Der Text des Antragsentwurfs hat nicht das erwartete Format und konnte "
+"daher nicht eindeutig in Zusammenfassung, Antragstext und Begründung "
+"getrennt werden. Bitte korrigiere vor dem Absenden den Antragstext."
+
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:7
+msgid "title_notice"
+msgstr "Hinweis"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:6
 msgid "btn_sort_by_identifier_or_title"
 msgstr "Nach Kennung/Titel sortieren"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:20
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:8
 msgid "btn_sort_by_supporter_count"
 msgstr "Nach Unterstützeranzahl sortieren"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:24
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:10
 msgid "btn_sort_by_date"
 msgstr "Nach Datum sortieren"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:13
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:15
 msgid "department_propositions"
 msgstr "Anträge in Gliederung"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:13
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:17
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:21
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:25
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:29
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:34
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:44
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:49
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:59
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:70
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:15
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:19
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:23
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:27
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:31
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:36
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:46
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:51
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:61
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:72
 msgid "remove_filter"
 msgstr "Filter entfernen"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:19
 msgid "subject_area_propositions"
 msgstr "Anträge in Themenbereich"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:21
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:23
 msgid "section"
 msgstr "Abschnitt"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:25
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:27
 msgid "type_propositions"
 msgstr "Anträge vom Typ"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:29
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:31
 msgid "phase_propositions"
 msgstr "Anträge in Abstimmungszeitraum"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:39
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:41
 msgid "status_propositions"
 msgstr "Anträge mit Status"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:54
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:56
 msgid "tagged_propositions"
 msgstr "Anträge mit Tags"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:65
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:67
 msgid "propositions_without_tags"
 msgstr "Anträge ohne Tags"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:74
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:76
 msgid "no_propositions_found"
 msgstr "Keine Anträge gefunden"
 
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:4
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:4
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:4
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:1
+msgid "title_draft"
+msgstr "Neuer Antragsentwurf"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:2
+msgid "notice_proposition_is_a_draft"
+msgstr "Dieser Antrag ist noch im Entwurfsstadium und nicht eingereicht!"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:3
+msgid "you_are_author_and_submitter"
+msgstr "Du hast diesen Entwurf erstellt und bist Antragsteller."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:4
+msgid "you_are_author_but_not_submitter"
+msgstr "Du hast diesen Entwurf angelegt, bist aber kein Antragsteller."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:5
+msgid "you_are_submitter"
+msgstr "Du bist Antragsteller."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:6
+msgid "draft_ready_to_submit"
+msgstr "Dieser Antragsentwurf kann eingereicht werden."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:7
+msgid "draft_needs_more_submitters"
+msgstr "Dieser Antragsentwurf braucht noch %(missing)s zusätzliche Antragsteller, um eingereicht werden zu können."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:8
+msgid "share_this_become_submitter_link"
+msgstr "Teile den folgenden Link mit anderen, die Antragsteller werden sollen:"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:11
+msgid "current_submitters"
+msgstr "Aktuell sind Antragsteller:"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:14
+msgid "invited_to_become_submitter"
+msgstr "Du wurdest dazu eingeladen, Antragsteller zu werden. Dein Anmeldename im Portal wird veröffentlicht, wenn du Antragsteller bist."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:17
+msgid "button_become_submitter"
+msgstr "Antragsteller werden"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:20
+msgid "notice_login"
+msgstr "Du musst dich erst anmelden."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_qualified.j2.jade:1
+msgid "title_qualified_proposition"
+msgstr "Zur Abstimmung zugelassener Antrag"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_qualified.j2.jade:2
+msgid "info_qualified_proposition"
+msgstr "Dieser Antrag hat die erforderliche Anzahl an Unterstützern erreicht und kann von den Verantwortlichen zur Abstimmung eingeplant werden."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_scheduled.j2.jade:1
+msgid "title_scheduled_proposition"
+msgstr "Zur Abstimmung eingeplanter Antrag"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_scheduled.j2.jade:2
+msgid "info_scheduled_proposition"
+msgstr "Dieser Antrag ist für die Abstimmung %(voting_phase)s %(ballot)s vorgesehen."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade:1
+msgid "title_submitted_proposition"
+msgstr "Eingereichter Antrag"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade:2
+msgid "info_submitted_proposition"
+msgstr "Dieser Antrag ist eingereicht und hat genügend Unterstützer, um zur Abstimmung zugelassen zu werden."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade:3
+msgid "current_user_is_submitter"
+msgstr "Du bist Antragsteller."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade:4
+msgid "current_user_is_submitter_and_supporter"
+msgstr "Wenn du deine Unterstützung zurückziehst, bleibst du weiterhin Antragsteller."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade:5
+msgid "current_user_is_supporter_not_submitter"
+msgstr "Du unterstützt diesen Antrag."
+
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:2
+msgid "created_by"
+msgstr "Erstellt von %(author)s"
+
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:6
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:6
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:6
 msgid "submitted_on"
 msgstr "Eingereicht am %(date)s"
 
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:6
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:8
 msgid "finished_on"
 msgstr "Abgeschlossen am %(date)s"
 
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:6
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:8
 msgid "qualified_on"
 msgstr "Zur Abstimmung qualifiziert am %(date)s"
 
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:8
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:10
 msgid "voting_ends_at"
 msgstr "Abstimmung endet um %(datetime)s"
 
@@ -874,7 +999,19 @@ msgstr "Letzte Aktivität"
 msgid "label_departments_subject_areas"
 msgstr "Gliederungen und Themenbereiche"
 
-#: src/ekklesia_portal/concepts/user/templates/user.j2.jade:18
+#: src/ekklesia_portal/concepts/user/templates/user.j2.jade:12
+msgid "member_in_area_explanation"
+msgstr "Bitte die Teilnahme an den Themenbereichen wählen:"
+
+#: src/ekklesia_portal/concepts/user/templates/user.j2.jade:19
+msgid "button_member_in_area"
+msgstr "Teilnahme:"
+
+#: src/ekklesia_portal/concepts/user/templates/user.j2.jade:21
+msgid "button_not_member_in_area"
+msgstr "KEINE Teilnahme:"
+
+#: src/ekklesia_portal/concepts/user/templates/user.j2.jade:28
 msgid "label_groups"
 msgstr "Gruppen"
 
@@ -925,8 +1062,10 @@ msgstr "Stichtag"
 #: src/ekklesia_portal/helper/missing_translations.py:3
 msgid "alert_ekklesia_login_not_allowed"
 msgstr ""
-"Du kannst die Anwendung nicht per %(name)s nutzen, da dir die "
-"erforderliche Rolle '%(role)s' fehlt."
+"Du kannst die Anwendung im Moment nicht per %(name)s nutzen, da dir die "
+"erforderliche Rolle '%(role)s' fehlt. Nach der Registrierung kann es bis "
+"zu einer Stunde dauern, bis dein Account überprüft wurde und du das "
+"Antragsportal nutzen kannst."
 
 #: src/ekklesia_portal/helper/missing_translations.py:4
 msgid "alert_logged_in_to"
@@ -1142,15 +1281,6 @@ msgstr "Nein"
 msgid "vote_by_user_abstention"
 msgstr "Enthaltung"
 
-msgid "button_member_in_area"
-msgstr "Teilnahme:"
-
-msgid "button_not_member_in_area"
-msgstr "KEINE Teilnahme:"
-
-msgid "member_in_area_explanation"
-msgstr "Bitte die Teilnahme an den Themenbereichen wählen:"
-
 #~ msgid "translation"
 #~ msgstr "Übersetzung"
 
@@ -1227,3 +1357,10 @@ msgstr "Bitte die Teilnahme an den Themenbereichen wählen:"
 
 #~ msgid "label_sub"
 #~ msgstr "SUB (Anwendungsspezifische ID)"
+
+#~ msgid "title_new_proposition"
+#~ msgstr "Neuer Antrag"
+
+#~ msgid "submit_draft"
+#~ msgstr "Antragsentwurf erstellen"
+

--- a/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
+++ b/src/ekklesia_portal/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-05 17:57+0000\n"
+"POT-Creation-Date: 2020-12-08 17:32+0000\n"
 "PO-Revision-Date: 2015-09-06 22:42+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -16,19 +16,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.8.0\n"
+"Generated-By: Babel 2.9.0\n"
 
 #: src/ekklesia_portal/concepts/argument/argument_contracts.py:12
 #: src/ekklesia_portal/concepts/page/page_contracts.py:11
 #: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:24
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:47
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:54
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_contracts.py:12
 msgid "title"
 msgstr "Title"
 
 #: src/ekklesia_portal/concepts/argument/argument_contracts.py:13
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:25
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:51
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:28
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:58
 msgid "abstract"
 msgstr "Abstract"
 
@@ -45,9 +45,7 @@ msgstr "Details"
 #: src/ekklesia_portal/concepts/ekklesia_portal/contracts/token.py:14
 #: src/ekklesia_portal/concepts/page/page_contracts.py:19
 #: src/ekklesia_portal/concepts/policy/policy_contracts.py:30
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:65
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:78
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:92
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:86
 #: src/ekklesia_portal/concepts/proposition_note/proposition_note_contracts.py:20
 #: src/ekklesia_portal/concepts/proposition_type/proposition_type_contracts.py:18
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_contracts.py:24
@@ -100,8 +98,9 @@ msgstr "result"
 #: src/ekklesia_portal/concepts/ballot/ballot_contracts.py:12
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:23
 #: src/ekklesia_portal/concepts/document/document_contracts.py:11
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:35
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:34
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:7
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:15
 msgid "subject_area"
 msgstr "subject area"
 
@@ -114,7 +113,8 @@ msgstr "Voting phase"
 #: src/ekklesia_portal/concepts/ballot/ballot_contracts.py:14
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:25
 #: src/ekklesia_portal/concepts/document/templates/document.j2.jade:15
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:36
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:35
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:17
 #: src/ekklesia_portal/concepts/proposition_type/templates/proposition_type.j2.jade:3
 msgid "proposition_type"
 msgstr "Proposition type"
@@ -131,8 +131,8 @@ msgstr "not determined"
 
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:3
 #: src/ekklesia_portal/concepts/ballot/templates/ballot.j2.jade:7
-#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:9
-#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:10
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:12
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:13
 #: src/ekklesia_portal/concepts/proposition/templates/status/proposition_status_scheduled.j2.jade:6
 msgid "ballot"
 msgstr "Ballot"
@@ -143,7 +143,7 @@ msgstr "Ballot"
 #: src/ekklesia_portal/concepts/document/templates/document.j2.jade:10
 #: src/ekklesia_portal/concepts/page/templates/page.j2.jade:7
 #: src/ekklesia_portal/concepts/policy/templates/policy.j2.jade:7
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 #: src/ekklesia_portal/concepts/proposition_note/templates/proposition_note.j2.jade:7
 #: src/ekklesia_portal/concepts/proposition_type/templates/proposition_type.j2.jade:7
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:9
@@ -162,6 +162,7 @@ msgstr "Number of propositions"
 #: src/ekklesia_portal/concepts/department/templates/department.j2.jade:3
 #: src/ekklesia_portal/concepts/department/templates/department.j2.jade:5
 #: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:5
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:13
 #: src/ekklesia_portal/concepts/voting_phase/templates/voting_phase.j2.jade:19
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_contracts.py:15
 msgid "department"
@@ -325,6 +326,8 @@ msgid "button_login"
 msgstr "Login"
 
 #: src/ekklesia_portal/concepts/ekklesia_portal/templates/index.j2.jade:9
+#: src/ekklesia_portal/concepts/proposition/templates/new_proposition.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/new_proposition.j2.jade:3
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_new_draft.j2.jade:2
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_new_draft.j2.jade:3
 msgid "title_new_draft"
@@ -368,7 +371,7 @@ msgid "menu_propositions"
 msgstr "Propositions"
 
 #: src/ekklesia_portal/concepts/ekklesia_portal/templates/layout.j2.jade:34
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:49
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:51
 msgid "search_for"
 msgstr "Search for"
 
@@ -517,8 +520,8 @@ msgstr "Voting system"
 
 #: src/ekklesia_portal/concepts/policy/policy_helper.py:7
 #: src/ekklesia_portal/concepts/policy/policy_helper.py:8
-#: src/ekklesia_portal/concepts/proposition/proposition_helper.py:17
-#: src/ekklesia_portal/concepts/proposition/proposition_helper.py:18
+#: src/ekklesia_portal/concepts/proposition/proposition_helper.py:25
+#: src/ekklesia_portal/concepts/proposition/proposition_helper.py:26
 #: src/ekklesia_portal/concepts/proposition_note/proposition_note_helper.py:9
 #: src/ekklesia_portal/concepts/voting_phase/voting_phase_helper.py:7
 msgid "_"
@@ -545,53 +548,69 @@ msgstr "Policy"
 msgid "days"
 msgstr "days"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:26
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:48
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:25
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:55
 msgid "content"
 msgstr "Content"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:27
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:52
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:26
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:56
 msgid "motivation"
 msgstr "Motivation"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:28
-msgid "external_discussion_url"
-msgstr "Link to discussion"
-
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:29
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:59
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:27
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:57
 msgid "tags"
 msgstr "Tags"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:40
-msgid "voting_identifier"
-msgstr "Identifier for voting"
-
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:41
-msgid "status"
-msgstr "Status"
-
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:42
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:33
-msgid "visibility"
-msgstr "Visibility"
-
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:43
-msgid "external_fields"
-msgstr "Data for external systems"
-
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:54
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:37
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:60
 msgid "editing_remarks"
 msgstr "Editing remarks"
 
-#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:55
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:38
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:61
 msgid "editing_remarks_description"
 msgstr ""
 "You can say here, for example, which group is working on the proposition "
 "and how to submit improvements."
 
-#: src/ekklesia_portal/concepts/proposition/proposition_views.py:245
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:45
+msgid "voting_identifier"
+msgstr "Identifier for voting"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:46
+msgid "submitter_invitation_key"
+msgstr ""
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:47
+msgid "external_discussion_url"
+msgstr "Link to discussion"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:48
+msgid "status"
+msgstr "Status"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:49
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:35
+msgid "visibility"
+msgstr "Visibility"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:50
+msgid "external_fields"
+msgstr "Data for external systems"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:72
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:100
+msgid "button_create_draft"
+msgstr "Create Draft"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_contracts.py:119
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
+msgid "button_submit_draft"
+msgstr "Submit Proposition"
+
+#: src/ekklesia_portal/concepts/proposition/proposition_views.py:319
 msgid "change"
 msgstr "Change"
 
@@ -600,22 +619,21 @@ msgstr "Change"
 msgid "title_edit_proposition"
 msgstr "Edit Proposition"
 
-#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:14
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:9
+msgid "submitter_invitation_link"
+msgstr ""
+
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:17
 msgid "push_draft"
 msgstr "Push draft"
 
-#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:15
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:18
 msgid "exporter_target"
 msgstr "Export target"
 
-#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:19
+#: src/ekklesia_portal/concepts/proposition/templates/edit_proposition.j2.jade:22
 msgid "push_draft_button"
 msgstr "Push draft"
-
-#: src/ekklesia_portal/concepts/proposition/templates/new_proposition.j2.jade:2
-#: src/ekklesia_portal/concepts/proposition/templates/new_proposition.j2.jade:3
-msgid "title_new_proposition"
-msgstr "New Proposition"
 
 #: src/ekklesia_portal/concepts/proposition/templates/proposition.j2.jade:6
 msgid "tab_discussion"
@@ -669,27 +687,27 @@ msgstr "Retract support"
 msgid "button_share"
 msgstr "Share"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 msgid "button_external_discussion_url"
 msgstr "External discussion"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 msgid "button_goto_arguments"
 msgstr "Go to Arguments"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 msgid "button_goto_associated"
 msgstr "Go to Associated"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 msgid "button_report"
 msgstr "Report"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_actions.j2.jade:7
 msgid "note_button"
 msgstr "Notes"
 
-#: src/ekklesia_portal/concepts/proposition/templates/proposition_card.j2.jade:9
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_card.j2.jade:10
 msgid "title_motivation"
 msgstr "Motivation"
 
@@ -705,90 +723,194 @@ msgid_plural "supporters"
 msgstr[0] "Supporter"
 msgstr[1] "Supporters"
 
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade:1
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:2
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:2
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade:4
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:4
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:4
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:4
 #: src/ekklesia_portal/concepts/proposition/templates/proposition_small.j2.jade:12
 msgid "created_on"
 msgstr "Added on %(date)s"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:16
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:5
+msgid "title_submit_draft"
+msgstr ""
+
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:3
+msgid "alert_draft_not_fully_matched"
+msgstr ""
+
+#: src/ekklesia_portal/concepts/proposition/templates/proposition_submit_draft.j2.jade:7
+msgid "title_notice"
+msgstr "Note"
+
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:6
 msgid "btn_sort_by_identifier_or_title"
 msgstr "Sort by Identifier/Title"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:20
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:8
 msgid "btn_sort_by_supporter_count"
 msgstr "Sort by Supporter Count"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:24
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:10
 msgid "btn_sort_by_date"
 msgstr "Sort by Date"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:13
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:15
 msgid "department_propositions"
 msgstr "Propositions in department"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:13
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:17
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:21
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:25
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:29
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:34
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:44
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:49
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:59
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:70
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:15
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:19
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:23
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:27
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:31
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:36
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:46
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:51
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:61
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:72
 msgid "remove_filter"
 msgstr "Remove filter"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:17
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:19
 msgid "subject_area_propositions"
 msgstr "Propositions in subject area"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:21
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:23
 msgid "section"
 msgstr "Section"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:25
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:27
 msgid "type_propositions"
 msgstr "Propositions of type"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:29
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:31
 msgid "phase_propositions"
 msgstr "Propositions in voting phase"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:39
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:41
 msgid "status_propositions"
 msgstr "Propositions with state"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:54
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:56
 msgid "tagged_propositions"
 msgstr "Tagged propositions"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:65
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:67
 msgid "propositions_without_tags"
 msgstr "Propositions without tags"
 
-#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:74
+#: src/ekklesia_portal/concepts/proposition/templates/propositions.j2.jade:76
 msgid "no_propositions_found"
 msgstr "No propositions found"
 
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:4
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:4
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:4
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:1
+msgid "title_draft"
+msgstr "New Draft"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:2
+msgid "notice_proposition_is_a_draft"
+msgstr "This proposition is a draft and not submitted yet!"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:3
+msgid "you_are_author_and_submitter"
+msgstr "You have created this draft and are submitter."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:4
+msgid "you_are_author_but_not_submitter"
+msgstr "You have created this draft but are not submitter"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:5
+msgid "you_are_submitter"
+msgstr "You are submitter."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:6
+msgid "draft_ready_to_submit"
+msgstr "This draft can be submitted."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:7
+msgid "draft_needs_more_submitters"
+msgstr "This draft needs %(missing)s more submitters in order to be submitted."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:8
+msgid "share_this_become_submitter_link"
+msgstr "Share this link to invite more submitters:"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:11
+msgid "current_submitters"
+msgstr "Currently, submitters are:"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:14
+msgid "invited_to_become_submitter"
+msgstr "You have been invited to become submitter. Your login name for the portal will be published when you become submitter."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:17
+msgid "button_become_submitter"
+msgstr "Become Submitter"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_draft.j2.jade:20
+msgid "notice_login"
+msgstr "You must login first."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_qualified.j2.jade:1
+msgid "title_qualified_proposition"
+msgstr "Proposition Qualified For Voting"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_qualified.j2.jade:2
+msgid "info_qualified_proposition"
+msgstr "This proposition has enough supporters so the administrator can schedule it for voting."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_scheduled.j2.jade:1
+msgid "title_scheduled_proposition"
+msgstr "Scheduled Proposition"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_scheduled.j2.jade:2
+msgid "info_scheduled_proposition"
+msgstr "This proposition is scheduled for the voting %(voting_phase)s %(ballot)s."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade:1
+msgid "title_submitted_proposition"
+msgstr "Edit Proposition"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade:2
+msgid "info_submitted_proposition"
+msgstr "This proposition has been submitted and has enough supporters to be scheduled for"
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade:3
+msgid "current_user_is_submitter"
+msgstr "You are submitter".
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade:4
+msgid "current_user_is_submitter_and_supporter"
+msgstr "If you retract your support, you are still a submitter of the proposition."
+
+#: src/ekklesia_portal/concepts/proposition/templates/detail_top/proposition_detail_top_submitted.j2.jade:5
+msgid "current_user_is_supporter_not_submitter"
+msgstr "You support this proposition."
+
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_draft.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:2
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:2
+msgid "created_by"
+msgstr "Created by %(author)s"
+
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:6
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:6
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_submitted.j2.jade:6
 msgid "submitted_on"
 msgstr "Submitted on %(date)s"
 
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:6
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_finished.j2.jade:8
 msgid "finished_on"
 msgstr "Finished on %(date)s"
 
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:6
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:8
 msgid "qualified_on"
 msgstr "Qualified for voting on %(date)s"
 
-#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:8
+#: src/ekklesia_portal/concepts/proposition/templates/history/proposition_history_scheduled.j2.jade:10
 msgid "voting_ends_at"
 msgstr "Voting ends at %(datetime)s"
 
@@ -873,7 +995,19 @@ msgstr "Last activity"
 msgid "label_departments_subject_areas"
 msgstr "Departments and subject areas"
 
-#: src/ekklesia_portal/concepts/user/templates/user.j2.jade:18
+#: src/ekklesia_portal/concepts/user/templates/user.j2.jade:12
+msgid "member_in_area_explanation"
+msgstr "Please select the participation in the subject areas:"
+
+#: src/ekklesia_portal/concepts/user/templates/user.j2.jade:19
+msgid "button_member_in_area"
+msgstr "participation:"
+
+#: src/ekklesia_portal/concepts/user/templates/user.j2.jade:21
+msgid "button_not_member_in_area"
+msgstr "NO participation:"
+
+#: src/ekklesia_portal/concepts/user/templates/user.j2.jade:28
 msgid "label_groups"
 msgstr "Groups"
 
@@ -1141,17 +1275,6 @@ msgstr "No"
 msgid "vote_by_user_abstention"
 msgstr "Abstention"
 
-msgid "button_member_in_area"
-msgstr "participation:"
-
-msgid "button_not_member_in_area"
-msgstr "NO participation:"
-
-msgid "member_in_area_explanation"
-msgstr "Please select the participation in the subject areas:"
-
-
-
 #~ msgid "follow"
 #~ msgstr "Follow"
 
@@ -1216,4 +1339,10 @@ msgstr "Please select the participation in the subject areas:"
 
 #~ msgid "label_sub"
 #~ msgstr "SUB (application-specific ID)"
+
+#~ msgid "title_new_proposition"
+#~ msgstr "New Proposition"
+
+#~ msgid "submit_draft"
+#~ msgstr ""
 

--- a/tests/concepts/proposition/test_propositions.py
+++ b/tests/concepts/proposition/test_propositions.py
@@ -172,7 +172,7 @@ def test_update_as_global_admin(client, proposition_factory, logged_in_global_ad
     proposition = proposition_factory(title="test")
 
     res = client.get(f'/p/{proposition.id}/test/edit')
-    skip_items = ['created_at', 'submitted_at', 'qualified_at', 'ballot_id', 'modifies_id', 'replaces_id', 'search_vector']
+    skip_items = ['author_id', 'created_at', 'submitted_at', 'qualified_at', 'ballot_id', 'modifies_id', 'replaces_id', 'search_vector']
     expected = {k: v for k, v in proposition.to_dict().items() if k not in skip_items}
     form = assert_deform(res, expected)
 

--- a/tests/create_test_db.py
+++ b/tests/create_test_db.py
@@ -28,7 +28,7 @@ DOCUMENT_WP = '''# Wahlprogramm
 Text Section 1.1
 '''
 
-PUSH_DRAFT_EXTERNAL_TEMPLATE_DE = '''
+PUSH_DRAFT_EXTERNAL_TEMPLATE = '''
 Dieser Antragsentwurf wurde automatisch erstellt durch das Antragsportal
 
 {draft_link}
@@ -52,6 +52,14 @@ Dieser Antragsentwurf wurde automatisch erstellt durch das Antragsportal
 {motivation}
 '''
 
+PUSH_DRAFT_PORTAL_TEMPLATE = '''
+Der Antragsentwurf wird hier weiterentwickelt:
+
+{topic_url}
+
+Verbesserungsvorschläge und Verständnisfragen bitte dort einbringen.
+'''
+
 DOCUMENT_PROPOSE_CHANGE_EXPLANATION_DE = '''
 Stelle einen Wahlprogrammantrag, um dieses Programm zu ändern.
 Du kannst eine Änderung an einem Abschnitt vorschlagen, indem du auf dessen Überschrift klickst.
@@ -59,12 +67,11 @@ Auf der folgenden Seite kannst du den Text bearbeiten und weitere Informationen 
 '''
 
 NEW_DRAFT_EXPLANATION_DE = '''
-Nach dem Abschicken wird dein Antragsentwurf von der Antragskommission geprüft.
-Dein Antragsentwurf wird nach einer Prüfung durch die Antragskommission im Forum in der Kategorie Antragsentwicklung eingestellt.
-Anschließend wird der Entwurf im Forum in der Kategorie Antragsentwicklung als neues Thema angelegt.
+Nach dem Abschicken wird dein Antragsentwurf automatisch im Forum in der Kategorie Antragsentwicklung eingestellt.
 Der Text des Antrags kann dort von allen angemeldeten Benutzern bearbeitet werden wie in einem Wiki.
 Du kannst die Bearbeitung sperren lassen. Wende dich dazu an die Antragskommission.
 '''
+
 
 if __name__ == "__main__":
 
@@ -108,7 +115,8 @@ if __name__ == "__main__":
 
     gen_de = mimesis.Generic('de')
 
-    s.add(CustomizableText(lang='de', name='push_draft_external_template', text=PUSH_DRAFT_EXTERNAL_TEMPLATE_DE))
+    s.add(CustomizableText(lang='de', name='push_draft_external_template', text=PUSH_DRAFT_EXTERNAL_TEMPLATE))
+    s.add(CustomizableText(lang='de', name='push_draft_portal_template', text=PUSH_DRAFT_PORTAL_TEMPLATE))
     s.add(
         CustomizableText(
             lang='de', name='document_propose_change_explanation', text=DOCUMENT_PROPOSE_CHANGE_EXPLANATION_DE
@@ -119,6 +127,9 @@ if __name__ == "__main__":
     department_pps = Department(name='Piratenpartei Schweiz')
     department_zs = Department(name='Zentralschweiz')
     department_ppd = Department(name='Piratenpartei Deutschland')
+
+    department_ppd.exporter_settings = {"exporter_name": "testdiscourse", "exporter_description": "Ein Test-Discourse"}
+
     department_by = Department(name='Landesverband Bayern')
     department_opf = Department(name='Bezirksverband Oberpfalz')
     s.add(department_by)
@@ -146,16 +157,14 @@ if __name__ == "__main__":
     u3_oauth_token = OAuthToken(provider='ekklesia', token={})
     u3 = User(name="olaf", auth_type="oauth", profile=u3_profile, oauth_token=u3_oauth_token)
     ug1.members.extend([u1, u2, u3])
-    s.add(DepartmentMember(department=department_pps, member=u1, is_admin=True))
+    s.add(DepartmentMember(department=department_ppd, member=u1))
+    s.add(DepartmentMember(department=department_pps, member=u1))
     s.add(DepartmentMember(department=department_ppd, member=u3))
     u2.departments.extend([department_zs])
-    u1.areas.extend([subject_area_pps_in, subject_area_pps_pol])
+    u1.areas.extend([subject_area_ppd_allg, subject_area_pps_in])
     u2.areas.extend([subject_area_zs_in])
     u3.areas.extend([subject_area_ppd_allg])
 
-    voting_phase_type_pv = VotingPhaseType(
-        name='Piratenversammlung', voting_type=VotingType.ASSEMBLY, abbreviation='PV', secret_voting_possible=True
-    )
     voting_phase_type_ur = VotingPhaseType(
         name='Online-Urabstimmung', voting_type=VotingType.ONLINE, abbreviation='UR', secret_voting_possible=False
     )
@@ -163,17 +172,17 @@ if __name__ == "__main__":
         name='Bundesparteitag', voting_type=VotingType.ASSEMBLY, abbreviation='BPT', secret_voting_possible=True
     )
 
-    voting_phase_pps_pv = VotingPhase(
-        phase_type=voting_phase_type_pv,
+    voting_phase_ppd_bpt_scheduled = VotingPhase(
+        phase_type=voting_phase_type_bpt,
         target='2020-11-11',
         status=VotingStatus.SCHEDULED,
         secret=True,
-        title='Piratenversammlung 2020.2',
-        name='pv202',
-        description='eine **Piratenversammlung** in der Schweiz'
+        title='BPT 2020.1',
+        name='bpt201',
+        description='Der nächste Parteitag irgendwo'
     )
 
-    department_pps.voting_phases.extend([voting_phase_pps_pv])
+    department_ppd.voting_phases.extend([voting_phase_ppd_bpt_scheduled])
 
     voting_phase_zs_ur = VotingPhase(
         phase_type=voting_phase_type_ur,
@@ -209,7 +218,7 @@ if __name__ == "__main__":
         range_small_options=5,
         secret_minimum=20,
         secret_quorum=0.05,
-        submitter_minimum=5,
+        submitter_minimum=2,
         voting_duration=14,
         voting_system=VotingSystem.RANGE_APPROVAL
     )
@@ -240,7 +249,7 @@ if __name__ == "__main__":
     t2 = Tag(name="Tag2")
     t3 = Tag(name="Täääg3")
 
-    b1 = Ballot(area=subject_area_pps_in, voting=voting_phase_pps_pv, name="PP001/2/3/4", proposition_type=ptype_pol)
+    b1 = Ballot(area=subject_area_pps_in, voting=voting_phase_ppd_bpt_scheduled, name="PP001/2/3/4", proposition_type=ptype_pol)
     s.add(b1)
     q1 = Proposition(
         title="Ein Titel",
@@ -308,6 +317,7 @@ if __name__ == "__main__":
     s.add(b7)
     b7.propositions.append(q7)
     q8 = Proposition(
+        author=u1,
         title="Entstehender Antrag",
         content="Einfach so entstehend...",
         created_at=datetime.fromisoformat('2020-01-06'),

--- a/tests/importer/test_discourse.py
+++ b/tests/importer/test_discourse.py
@@ -19,7 +19,7 @@ RAW = f'''
 
 {ABSTRACT}
 
-## Antrag
+## Antragstext
 
 {CONTENT}
 
@@ -32,7 +32,7 @@ TOPIC = {'title': 'title'}
 
 POST = {'raw': RAW, 'topic_id': 2}
 
-EXPECTED_PARSED_CONTENT = {'abstract': ABSTRACT, 'content': CONTENT, 'motivation': MOTIVATION}
+EXPECTED_PARSED_CONTENT = {'abstract': ABSTRACT, 'content': CONTENT, 'motivation': MOTIVATION, 'all_matched': True}
 
 
 def test_parse_raw_content():
@@ -47,6 +47,6 @@ def test_import_discourse_post_as_proposition():
     topic_url = base_url + '/t/2'
     responses.add(responses.GET, post_url, body=json.dumps(POST))
     responses.add(responses.GET, topic_url, body=json.dumps(TOPIC))
-    res = import_discourse_post_as_proposition(base_url, 1)
+    res = import_discourse_post_as_proposition(dict(base_url=base_url), 1)
     expected = {'title': TOPIC['title'], 'external_discussion_url': topic_url, **EXPECTED_PARSED_CONTENT}
     assert res == expected


### PR DESCRIPTION
* new propositions are always created as drafts
* drafts not created by an admin are pushed to an external discussion
  system if available
* users can become additional submitters of a draft by using an invite
  link shown to submitters and admins
* drafts can be submitted by submitters if min submitter count is
  satisfied
* before submitting the draft, the current version of the proposition
  text is fetched back from the discussion system
* propositions show additional info according to their state (detail_top)

Limitations:

* Discourse is the only implementation supported as external discussion
  system
* Code is not generic enough in some places to support other external
  discussion systems readily
* Parsing the proposition text from the discussion system is quite
  primitive but should be sufficient in most cases. Users need to keep
  the headings generated by the portal. If parsing fails, users are
  warned in the submission form and can correct errors.

Closes #66